### PR TITLE
docs: add link to fork

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -3,7 +3,7 @@
   "description": "Tools for building completely customizable richtext editors with React.",
   "version": "0.72.4",
   "license": "MIT",
-  "repository": "git://github.com/ianstormtaylor/slate.git",
+  "repository": "https://github.com/skogsmaskin/slate/tree/sanity/packages/slate-react",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Hi @skogsmaskin! While digging down a skypack rabbit hole I was trying to find the source for `@sanity/slate-react`. It was tricky as my usual detective methods (like using https://cs.github.com/) failed and it was as if the code for this package was a Schrödingers Repo 😬 

Anyways that's why I'm suggesting we add a link to the fork code so that the [npm listing](https://www.npmjs.com/package/@sanity/slate-react) can take the next detective directly over here 😌 